### PR TITLE
Add a tiny cosmetic change to be more explicit

### DIFF
--- a/dict/trie/da.go
+++ b/dict/trie/da.go
@@ -238,7 +238,7 @@ func (d *DoubleArray) expand() {
 		(*dst)[i].Check = int32(-(i + 1))
 	}
 
-	start := -(*d)[0].Check
+	start := -(*d)[rootID].Check
 	end := -(*dst)[start].Base
 	(*dst)[srcSize].Base = -end
 	(*dst)[start].Base = int32(-(dstSize - 1))


### PR DESCRIPTION
I'm reading `kagome-dict` to understand how double-array works. I found a tiny improvement so that the code is more explicit.