### PR TITLE
feat: add "Name" field to dict.Dict struct (Issue #49)

### DIFF
--- a/dict/dict.go
+++ b/dict/dict.go
@@ -24,6 +24,8 @@ const (
 	CharDefDictFileName = "chardef.dict"
 	// UnkDictFileName is the default filename of an unknown dict.
 	UnkDictFileName = "unk.dict"
+	// DictNameFileName is the default filename of a dictionary name.
+	DictNameFileName = "name.dict"
 )
 
 // Dict represents a dictionary of a tokenizer.
@@ -39,6 +41,7 @@ type Dict struct {
 	InvokeList   InvokeList
 	GroupList    GroupList
 	UnkDict      UnkDict
+	Name         DictName
 }
 
 // CharacterCategory returns the category of a rune.
@@ -125,6 +128,12 @@ func (d *Dict) loadUnkDict(r io.Reader) error {
 	return nil
 }
 
+func (d *Dict) loadDictName(r io.Reader) error {
+	def := ReadDictName(r)
+	d.Name = def
+	return nil
+}
+
 // LoadDictFile loads a dictionary from a file.
 func LoadDictFile(path string) (d *Dict, err error) {
 	r, err := zip.OpenReader(path)
@@ -156,6 +165,7 @@ var loaders = map[string]dictionaryPartLoader{
 	ConnectionDictFileName: (*Dict).loadConnectionDict,
 	CharDefDictFileName:    (*Dict).loadCharDefDict,
 	UnkDictFileName:        (*Dict).loadUnkDict,
+	DictNameFileName:       (*Dict).loadDictName,
 }
 
 // Load loads a dictionary from a zipped reader.
@@ -193,6 +203,7 @@ var dictionaryPartFiles = []string{
 	ConnectionDictFileName,
 	CharDefDictFileName,
 	UnkDictFileName,
+	DictNameFileName,
 }
 
 type dictionaryPartSaver func(Dict, io.Writer) error
@@ -206,6 +217,7 @@ var savers = map[string]dictionaryPartSaver{
 	ConnectionDictFileName: Dict.saveConnectionDict,
 	CharDefDictFileName:    Dict.saveCharDefDict,
 	UnkDictFileName:        Dict.saveUnkDict,
+	DictNameFileName:       Dict.saveName,
 }
 
 // Save saves a dictionary in a zipped format.
@@ -271,5 +283,10 @@ func (d Dict) saveCharDefDict(w io.Writer) error {
 
 func (d Dict) saveUnkDict(w io.Writer) error {
 	_, err := d.UnkDict.WriteTo(w)
+	return err
+}
+
+func (d Dict) saveName(w io.Writer) error {
+	_, err := d.Name.WriteTo(w)
 	return err
 }

--- a/dict/dict_name.go
+++ b/dict/dict_name.go
@@ -1,0 +1,48 @@
+package dict
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"io"
+)
+
+// DictName represents the name of the dictionary to identify.
+type DictName string
+
+const UndefinedDictName = "unnamed dict"
+
+// ReadDictName reads gob encoded dictionary name and returns as DictName.
+//
+// For backward compatibility, if a dictionary name is not defined or empty, it
+// returns UndefinedDictName.
+func ReadDictName(r io.Reader) DictName {
+	if r == nil {
+		return UndefinedDictName
+	}
+
+	var ret DictName
+	dec := gob.NewDecoder(r)
+	if err := dec.Decode(&ret); err != nil {
+		return UndefinedDictName
+	}
+	if string(ret) == "" {
+		return UndefinedDictName
+	}
+
+	return ret
+}
+
+// WriteTo implements the io.WriteTo interface.
+func (d DictName) WriteTo(w io.Writer) (n int64, err error) {
+	if w == nil {
+		return 0, errors.New("given writer is nil")
+	}
+
+	var b bytes.Buffer
+	enc := gob.NewEncoder(&b)
+	if err := enc.Encode(string(d)); err != nil {
+		return 0, err
+	}
+	return b.WriteTo(w)
+}

--- a/dict/dict_name_test.go
+++ b/dict/dict_name_test.go
@@ -67,10 +67,9 @@ func TestDictName_bad_input(t *testing.T) {
 }
 
 func TestDictName_WriteTo(t *testing.T) {
-	// Nil writer should return error.
 	name := DictName("test_dict")
 
-	// Get gob encoded dictionary name.
+	// Nil writer should return error.
 	_, err := name.WriteTo(nil)
 
 	// Assert error.

--- a/dict/dict_name_test.go
+++ b/dict/dict_name_test.go
@@ -1,0 +1,85 @@
+package dict
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDictName_golden(t *testing.T) {
+	rawName := DictName("test_dict")
+
+	// Get gob encoded dictionary name.
+	var gobName bytes.Buffer
+	if _, err := rawName.WriteTo(&gobName); err != nil {
+		t.Errorf("failed to get encoded name data: %v", err)
+	}
+
+	// Decode gob encoded dictionary name.
+	decName := ReadDictName(&gobName)
+
+	// Assert be equal.
+	if string(rawName) != string(decName) {
+		t.Errorf("want %v, got %v", rawName, decName)
+	}
+}
+
+func TestDictName_bad_input(t *testing.T) {
+	t.Run("empty name", func(t *testing.T) {
+		name := DictName("")
+
+		// Get gob encoded dictionary name.
+		var gobName bytes.Buffer
+		if _, err := name.WriteTo(&gobName); err != nil {
+			t.Errorf("failed to encode dict name: %v", err)
+		}
+
+		// Decode gob encoded dictionary name.
+		got := string(ReadDictName(&gobName))
+
+		// Assert be equal to default name.
+		want := UndefinedDictName
+		if want != got {
+			t.Errorf("empty name should return default name. want %v, got %v", want, got)
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		// Nil input shuold return default name.
+		got := string(ReadDictName(nil))
+
+		// Assert be equal to default name.
+		want := UndefinedDictName
+		if want != got {
+			t.Errorf("nil input should return default name. want %v, got %v", want, got)
+		}
+	})
+
+	t.Run("bad gob data", func(t *testing.T) {
+		// Bad gob data should return default name.
+		got := string(ReadDictName(bytes.NewReader([]byte{0x00})))
+
+		// Assert be equal to default name.
+		want := UndefinedDictName
+		if want != got {
+			t.Errorf("bad encoded data should return default name. want %v, got %v", want, got)
+		}
+	})
+}
+
+func TestDictName_WriteTo(t *testing.T) {
+	// Nil writer should return error.
+	name := DictName("test_dict")
+
+	// Get gob encoded dictionary name.
+	_, err := name.WriteTo(nil)
+
+	// Assert error.
+	if err == nil {
+		t.Error("nil writer should return error")
+	}
+	// Assert error message.
+	want := "given writer is nil"
+	if want != err.Error() {
+		t.Errorf("want %v, got %v", want, err.Error())
+	}
+}

--- a/dict/dict_test.go
+++ b/dict/dict_test.go
@@ -68,12 +68,17 @@ func newTestDict(t *testing.T) *Dict {
 				[]string{"bb1", "bb2", "bb3"},
 			},
 		},
+		Name: "testDict",
 	}
 }
 
 // save <--> load
 func Test_DictSaveLoad(t *testing.T) {
 	dict := newTestDict(t)
+
+	if nameDict := dict.Name; nameDict != "testDict" {
+		t.Fatalf("unexpected dict name, %v", nameDict)
+	}
 
 	var b bytes.Buffer
 	zw := zip.NewWriter(&b)
@@ -95,8 +100,8 @@ func Test_DictSaveLoad(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(dict, got) {
-		t.Errorf("want %+v, got %+v", dict, got)
-		fmt.Printf("%T\n", got.ContentsMeta)
-		fmt.Printf("%T\n", dict.ContentsMeta)
+		t.Errorf("\nwant %+v\ngot %+v\n", dict, got)
+		fmt.Printf("got type: %T\n", got.ContentsMeta)
+		fmt.Printf("want type: %T\n", dict.ContentsMeta)
 	}
 }

--- a/dict/unkdict.go
+++ b/dict/unkdict.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 )
 
@@ -121,9 +120,9 @@ func ReadUnkDic(r io.Reader) (UnkDict, error) {
 	if err != nil {
 		return d, err
 	}
-	d.ContentsMeta =me
+	d.ContentsMeta = me
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return d, err
 	}

--- a/ipa/dict.go
+++ b/ipa/dict.go
@@ -10,16 +10,19 @@ import (
 	"github.com/ikawaha/kagome-dict/dict"
 )
 
+// dictName represents a dictionary name to identify.
+// You can retrieve this name via dict.Dict.Name field.
+const dictName = "IPA"
+
 type FeatureIndex = int
 
+// Features are information given to a word, such as follows:
+// 公園	名詞,一般,*,*,*,*,公園,コウエン,コーエン
+// に	助詞,格助詞,一般,*,*,*,に,ニ,ニ
+// 行っ	動詞,自立,*,*,五段・カ行促音便,連用タ接続,行く,イッ,イッ
+// た	助動詞,*,*,*,特殊・タ,基本形,た,タ,タ
+// EOS
 const (
-	// Features are information given to a word, such as follows:
-	// 公園	名詞,一般,*,*,*,*,公園,コウエン,コーエン
-	// に	助詞,格助詞,一般,*,*,*,に,ニ,ニ
-	// 行っ	動詞,自立,*,*,五段・カ行促音便,連用タ接続,行く,イッ,イッ
-	// た	助動詞,*,*,*,特殊・タ,基本形,た,タ,タ
-	// EOS
-
 	// POSHierarchy represents part-of-speech hierarchy
 	// e.g. Columns 動詞,自立,*,* are POSs which hierarchy depth is 4.
 	POSHierarchy = 4
@@ -34,7 +37,6 @@ const (
 	// Pronunciation represents 発音 (e.g. コーエン)
 	Pronunciation = 8
 )
-
 
 type systemDict struct {
 	once sync.Once
@@ -75,7 +77,7 @@ func loadDict(full bool) *dict.Dict {
 		panic(err)
 	}
 	r := bytes.NewReader(b)
-	zr,err := zip.NewReader(r, r.Size())
+	zr, err := zip.NewReader(r, r.Size())
 	if err != nil {
 		panic(err)
 	}
@@ -83,5 +85,8 @@ func loadDict(full bool) *dict.Dict {
 	if err != nil {
 		panic(err)
 	}
+
+	d.Name = dict.DictName(dictName)
+
 	return d
 }

--- a/ipa/dict_test.go
+++ b/ipa/dict_test.go
@@ -90,6 +90,17 @@ func Test_ContentsMeta(t *testing.T) {
 	}
 }
 
+func Test_Dict_get_dictionary_name(t *testing.T) {
+	d := Dict()
+
+	want := dictName
+	got := string(d.Name)
+
+	if want != got {
+		t.Errorf("want %s, got %s", want, got)
+	}
+}
+
 /*
 func Test_InflectionalType(t *testing.T) {
 	tnz, err := tokenizer.New(Dict())

--- a/ipa/go.mod
+++ b/ipa/go.mod
@@ -3,3 +3,5 @@ module github.com/ikawaha/kagome-dict/ipa
 go 1.19
 
 require github.com/ikawaha/kagome-dict v1.0.10
+
+replace github.com/ikawaha/kagome-dict => ../

--- a/uni/dict.go
+++ b/uni/dict.go
@@ -10,16 +10,19 @@ import (
 	"github.com/ikawaha/kagome-dict/dict"
 )
 
+// dictName represents a dictionary name to identify.
+// You can retrieve this name via dict.Dict.Name field.
+const dictName = "Uni"
+
 type FeatureIndex = int
 
+// Features are information given to a word, such as follows:
+// 公園	名詞,普通名詞,一般,*,*,*,コウエン,公園,公園,コーエン,公園,コーエン,漢,*,*,*,*
+// に	助詞,格助詞,*,*,*,*,ニ,に,に,ニ,に,ニ,和,*,*,*,*
+// 行っ	動詞,非自立可能,*,*,五段-カ行,連用形-促音便,イク,行く,行っ,イッ,行く,イク,和,*,*,*,*
+// た	助動詞,*,*,*,助動詞-タ,終止形-一般,タ,た,た,タ,た,タ,和,*,*,*,*
+// EOS
 const (
-	// Features are information given to a word, such as follows:
-	// 公園	名詞,普通名詞,一般,*,*,*,コウエン,公園,公園,コーエン,公園,コーエン,漢,*,*,*,*
-	// に	助詞,格助詞,*,*,*,*,ニ,に,に,ニ,に,ニ,和,*,*,*,*
-	// 行っ	動詞,非自立可能,*,*,五段-カ行,連用形-促音便,イク,行く,行っ,イッ,行く,イク,和,*,*,*,*
-	// た	助動詞,*,*,*,助動詞-タ,終止形-一般,タ,た,た,タ,た,タ,和,*,*,*,*
-	// EOS
-
 	// POSHierarchy represents part-of-speech hierarchy
 	// e.g. Columns 動詞,非自立可能,*,* are POSs which hierarchy depth is 4.
 	POSHierarchy = 4
@@ -101,7 +104,7 @@ func loadDict(full bool) *dict.Dict {
 		panic(err)
 	}
 	r := bytes.NewReader(b)
-	zr,err := zip.NewReader(r, r.Size())
+	zr, err := zip.NewReader(r, r.Size())
 	if err != nil {
 		panic(err)
 	}
@@ -109,5 +112,8 @@ func loadDict(full bool) *dict.Dict {
 	if err != nil {
 		panic(err)
 	}
+
+	d.Name = dict.DictName(dictName)
+
 	return d
 }

--- a/uni/dict_test.go
+++ b/uni/dict_test.go
@@ -90,6 +90,17 @@ func Test_ContentsMeta(t *testing.T) {
 	}
 }
 
+func Test_Dict_get_dictionary_name(t *testing.T) {
+	d := Dict()
+
+	want := dictName
+	got := string(d.Name)
+
+	if want != got {
+		t.Errorf("want %s, got %s", want, got)
+	}
+}
+
 /*
 func Test_InflectionalType(t *testing.T) {
 	tnz, err := tokenizer.New(Dict())

--- a/uni/go.mod
+++ b/uni/go.mod
@@ -3,3 +3,5 @@ module github.com/ikawaha/kagome-dict/uni
 go 1.19
 
 require github.com/ikawaha/kagome-dict v1.0.10
+
+replace github.com/ikawaha/kagome-dict => ../


### PR DESCRIPTION
This PR:

1. Adds "Name" field to dict.Dict struct. 1715aa21ba771de0474e865c19056a682e49c904
2. Closes #49

Chore:

1. Fix deprecated package `io/ioutil` to `io`. https://github.com/ikawaha/kagome-dict/commit/20ca748a949467be6326f0b1ecf55413bda2e518
1. Add line breaks to test error message for readability. To ease compare the diff on err.
   - https://github.com/ikawaha/kagome-dict/commit/527bdea81cb152fea7ae1a54d5467f855c0dd6dd#diff-785785b8fc667d99dac42667c7b0e3b79e4840d392789771307cf642acd970e0R103
1. Points IPA and Uni's "github.com/ikawaha/kagome-dict" package in their go.mod to local (`../dict`).
   - IPA: https://github.com/ikawaha/kagome-dict/commit/af44380e335cf77554044fe708f4b90f699efc84#diff-421034359eb70a3dce63d79f2a9e0ad43f78a07bddb223b81c4d253f6982dd49R7
   - Uni: https://github.com/ikawaha/kagome-dict/commit/a9dfa2c2bccf8344b51e65b7cb42165a41da8c03#diff-40fc86218e6843eb237b25397c47342fcb63d7c8ce4dddeb51ad104ad94f8e93R7