### PR TITLE
fix: read vectors in connection.dict at once

### DIFF
--- a/dict/connection.go
+++ b/dict/connection.go
@@ -45,10 +45,8 @@ func ReadConnectionTable(r io.Reader) (ConnectionTable, error) {
 		return ret, err
 	}
 	ret.Vec = make([]int16, ret.Row*ret.Col)
-	for i := range ret.Vec {
-		if err := binary.Read(r, binary.LittleEndian, &ret.Vec[i]); err != nil {
-			return ret, err
-		}
+	if err := binary.Read(r, binary.LittleEndian, &ret.Vec); err != nil {
+		return ret, err
 	}
 	return ret, nil
 }


### PR DESCRIPTION
## WHAT
connection.dictを読み込むときに値を1つずつfor文で読み込んでいますが、
`binary.Read` 関数にはsliceを直接渡すことができるようです。
connection.dictは巨大なファイルなので、ここを一度にreadさせることで、辞書の読み込みがかなり速くなります。

[en] When reading connection.dict, values are being read one by one using a for loop, but it seems that the binary.Read function can directly accept a slice. Since connection.dict occupies a large portion of the dictionary's size, allowing it to be read all at once can significantly speed up the dictionary loading process.

## WHY
辞書の読み込みの高速化のため

[en] To speed up dictionary loading.

## TEST
```
func Test_LoadDict(t *testing.T) {
	_, _ = dict.LoadShrink("unidic-cwj-202302_full.dict")
}
```

変更前 [Before]
```
=== RUN   Test_LoadDict
--- PASS: Test_LoadDict (18.65s)
```

変更後 [After]
```
=== RUN   Test_LoadDict
--- PASS: Test_LoadDict (9.32s)
```

手元のmac、`unidic-cwj-202302_full.dict` で読み込みが9秒速くなります