### PR TITLE
chore: Fix Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ikawaha/kagome-dict
 
-go 1.24.1
+go 1.23.0
 
 require golang.org/x/text v0.23.0
 


### PR DESCRIPTION
issue https://github.com/ikawaha/kagome-dict/issues/66

Fix Go version to v1.23.0.